### PR TITLE
Fixed bug that caused notifications to only be delivered in the foreground on iOS

### DIFF
--- a/src/FirebaseNet/Messaging/Message.cs
+++ b/src/FirebaseNet/Messaging/Message.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -68,6 +69,7 @@ namespace FirebaseNet.Messaging
         /// open a network connection to your server.
         /// </summary>
         [JsonProperty(PropertyName = "priority")]
+        [JsonConverter(typeof(StringEnumConverter))]
         public MessagePriority? Priority { get; set; }
 
         /// <summary>


### PR DESCRIPTION
There was a bug in the serialization of the FCMMessage Priority property. This enum was serializing to an integer value in the JSON, but the Firebase documentation says this should be a string with a value of either 'normal' or 'high'. 

Before this fix, setting the Priority to FCMMessagePriority.high would set the priority value to 1 in the JSON sent to Firebase. This causes notifications to only be delivered when the app is in the foreground on iOS 10.