### PR TITLE
Add Android notification channel support.

### DIFF
--- a/src/FirebaseNet/Messaging/AndroidNotification.cs
+++ b/src/FirebaseNet/Messaging/AndroidNotification.cs
@@ -78,5 +78,11 @@ namespace FirebaseNet.Messaging
         [JsonProperty(PropertyName = "title_loc_args")]
         public string TitleLocArgs { get; set; }
 
+
+        /// <summary>
+        /// Indicates the string value of the notification channel ID that the notification should be sent to in an Android app
+        /// </summary>
+        [JsonProperty(PropertyName = "android_channel_id")]
+        public string ChannelId { get; set; }
     }
 }


### PR DESCRIPTION
With notification channels now part of Android Oreo and up, it would be nice to be able to set the channel id when sending from this package.  I did test this change to make sure I got the serialized property name correct, and it works as expected.